### PR TITLE
fix: set max image width on pdf

### DIFF
--- a/src/content_segment_exporter.py
+++ b/src/content_segment_exporter.py
@@ -2,6 +2,7 @@ import os
 import shutil
 
 import cv2
+import imutils
 from fpdf import FPDF
 
 from subtitle_webvtt_parser import SubtitleWebVTTParser
@@ -40,7 +41,7 @@ class ContentSegmentPdfBuilder:
             The filepath for the output pdf
         """
         self.__prepare_tmp_folder__()
-        pdf = FPDF(format="letter")
+        pdf = FPDF()
 
         for i in range(0, len(pages)):
             # Temporarily save the frames
@@ -49,8 +50,7 @@ class ContentSegmentPdfBuilder:
             pdf.add_page()
 
             # Add the image
-            pdf.set_xy(6.0, 6.0)
-            pdf.image("./tmp/{}_frame.jpeg".format(i))
+            pdf.image("./tmp/{}_frame.jpeg".format(i), w=195)
 
             # Add the captions
             pdf.set_font("Arial", "", 12)

--- a/src/content_segment_exporter.py
+++ b/src/content_segment_exporter.py
@@ -2,7 +2,6 @@ import os
 import shutil
 
 import cv2
-import imutils
 from fpdf import FPDF
 
 from subtitle_webvtt_parser import SubtitleWebVTTParser


### PR DESCRIPTION
### Problem:

When the resolution of lecture videos are too large, it embeds images into PDF that are larger than the PDF itself. For instance,

![image](https://user-images.githubusercontent.com/18586991/143664167-93debce4-2769-4426-9a57-02913096ea40.png)

### Solution:

Set the width of images when embedding them in PDFs
